### PR TITLE
Handle file request cancellation gracefully

### DIFF
--- a/app/src/main/java/mgks/os/webview/MainActivity.java
+++ b/app/src/main/java/mgks/os/webview/MainActivity.java
@@ -120,6 +120,14 @@ public class MainActivity extends AppCompatActivity {
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
             getWindow().setStatusBarColor(getResources().getColor(R.color.colorPrimary));
             Uri[] results = null;
+            if (resultCode == Activity.RESULT_CANCELED) {
+                if (requestCode == asw_file_req) {
+                    // If the file request was cancelled (i.e. user exited camera),
+                    // we must still send a null value in order to ensure that future attempts
+                    // to pick files will still work.
+                    asw_file_path.onReceiveValue(null);
+                }
+            }
             if (resultCode == Activity.RESULT_OK) {
                 if (requestCode == asw_file_req) {
                     if (null == asw_file_path) {
@@ -285,9 +293,6 @@ public class MainActivity extends AppCompatActivity {
             public boolean onShowFileChooser(WebView webView, ValueCallback<Uri[]> filePathCallback, FileChooserParams fileChooserParams){
             	if(check_permission(2) && check_permission(3)) {
 					if (ASWP_FUPLOAD) {
-						if (asw_file_path != null) {
-							asw_file_path.onReceiveValue(null);
-						}
 						asw_file_path = filePathCallback;
 						Intent takePictureIntent = null;
 						if (ASWP_CAMUPLOAD) {


### PR DESCRIPTION
If the file request was cancelled (i.e. because the user exited from the camera without taking a photo, or dismissed the intent chooser rather than making a choice), a null value must be sent in order to prevent future file requests from failing.

We were finding that although the first request worked fine, and subsequent requests also worked if you'd taken a photo / chosen a file, if you cancelled the process instead, the intent chooser simply doesn't show when you subsequently trigger the file input again.  This doesn't seem to happen in all cases; I tried to put together a minimal test case, but haven't managed to replicate the issue in a minimal enough form to share yet.

While debugging the issue, I came across [this StackOverflow post](https://stackoverflow.com/a/50606783), which suggests that it's important to call the callback with a null parameter if the request was cancelled.  After adding handling for the `RESULT_CANCELED` result in `onActivityResult()`, I started getting an app crash when re-triggering the file input after the cancellation - until I removed the call to `asw_file_path.onReceiveValue(null);` from `onShowFileChooser()`, which I think might have been intended to serve the same purpose as the `RESULT_CANCELED` handler, but seems to conflict with it.